### PR TITLE
Fixed copyright year by changing utcnow function to today in generate.py

### DIFF
--- a/generate
+++ b/generate
@@ -63,7 +63,7 @@ for language in languages:
             {
                 name + "_active": "active",
                 "static_path": STATIC_PATH,
-                "copyright_year": datetime.datetime.utcnow().year
+                "copyright_year": datetime.datetime.today().year
             }
         )
         os.makedirs(os.path.join('build', language), exist_ok=True)


### PR DESCRIPTION
The `utcnow()` function is deprecated now and it should be changed to `today()` function for proper functioning of the website .

![image](https://github.com/abhishek-kuma/sympy.github.com/assets/140839576/0dd194de-4e72-4795-b7ee-9bb841b884f2)
